### PR TITLE
Add LinkML data validation

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -1,0 +1,13 @@
+[[source]]
+url = "https://pypi.org/simple"
+verify_ssl = true
+name = "pypi"
+
+[packages]
+linkml = "*"
+jsonschema = "*"
+
+[dev-packages]
+
+[requires]
+python_version = "3.9"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,0 +1,396 @@
+{
+    "_meta": {
+        "hash": {
+            "sha256": "d34834b2ebccbc2d3b5e4e01c5db71ecb297bdb7022e84783bd2b46b8d2a2895"
+        },
+        "pipfile-spec": 6,
+        "requires": {
+            "python_version": "3.9"
+        },
+        "sources": [
+            {
+                "name": "pypi",
+                "url": "https://pypi.org/simple",
+                "verify_ssl": true
+            }
+        ]
+    },
+    "default": {
+        "antlr4-python3-runtime": {
+            "hashes": [
+                "sha256:31f5abdc7faf16a1a6e9bf2eb31565d004359b821b09944436a34361929ae85a"
+            ],
+            "version": "==4.9.2"
+        },
+        "argparse": {
+            "hashes": [
+                "sha256:62b089a55be1d8949cd2bc7e0df0bddb9e028faefc8c32038cc84862aefdd6e4",
+                "sha256:c31647edb69fd3d465a847ea3157d37bed1f95f19760b11a47aa91c04b666314"
+            ],
+            "version": "==1.4.0"
+        },
+        "attrs": {
+            "hashes": [
+                "sha256:31b2eced602aa8423c2aea9c76a724617ed67cf9513173fd3a4f03e3a929c7e6",
+                "sha256:832aa3cde19744e49938b91fea06d69ecb9e649c93ba974535d08ad92164f700"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==20.3.0"
+        },
+        "cachetools": {
+            "hashes": [
+                "sha256:1d9d5f567be80f7c07d765e21b814326d78c61eb0c3a637dffc0e5d1796cb2e2",
+                "sha256:f469e29e7aa4cff64d8de4aad95ce76de8ea1125a16c68e0d93f65c3c3dc92e9"
+            ],
+            "markers": "python_version ~= '3.5'",
+            "version": "==4.2.1"
+        },
+        "certifi": {
+            "hashes": [
+                "sha256:1a4995114262bffbc2413b159f2a1a480c969de6e6eb13ee966d470af86af59c",
+                "sha256:719a74fb9e33b9bd44cc7f3a8d94bc35e4049deebe19ba7d8e108280cfd59830"
+            ],
+            "version": "==2020.12.5"
+        },
+        "cfgraph": {
+            "hashes": [
+                "sha256:b57fe7044a10b8ff65aa3a8a8ddc7d4cd77bf511b42e57289cd52cbc29f8fe74"
+            ],
+            "version": "==0.2.1"
+        },
+        "chardet": {
+            "hashes": [
+                "sha256:0d6f53a15db4120f2b08c94f11e7d93d2c911ee118b6b30a04ec3ee8310179fa",
+                "sha256:f864054d66fd9118f2e67044ac8981a54775ec5b67aed0441892edb553d21da5"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
+            "version": "==4.0.0"
+        },
+        "click": {
+            "hashes": [
+                "sha256:d2b5255c7c6349bc1bd1e59e08cd12acbbd63ce649f2588755783aa94dfb6b1a",
+                "sha256:dacca89f4bfadd5de3d7489b7c8a566eee0d3676333fbb50030263894c38c0dc"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
+            "version": "==7.1.2"
+        },
+        "frozendict": {
+            "hashes": [
+                "sha256:774179f22db2ef8a106e9c38d4d1f8503864603db08de2e33be5b778230f6e45"
+            ],
+            "version": "==1.2"
+        },
+        "graphviz": {
+            "hashes": [
+                "sha256:3cad5517c961090dfc679df6402a57de62d97703e2880a1a46147bb0dc1639eb",
+                "sha256:d2d25af1c199cad567ce4806f0449cb74eb30cf451fd7597251e1da099ac6e57"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'",
+            "version": "==0.16"
+        },
+        "hbreader": {
+            "hashes": [
+                "sha256:9a6e76c9d1afc1b977374a5dc430a1ebb0ea0488205546d4678d6e31cc5f6801",
+                "sha256:d2c132f8ba6276d794c66224c3297cec25c8079d0a4cf019c061611e0a3b94fa"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==0.9.1"
+        },
+        "idna": {
+            "hashes": [
+                "sha256:b307872f855b18632ce0c21c5e45be78c0ea7ae4c15c828c20788b26921eb3f6",
+                "sha256:b97d804b1e9b523befed77c48dacec60e6dcb0b5391d57af6a65a312a90648c0"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==2.10"
+        },
+        "isodate": {
+            "hashes": [
+                "sha256:2e364a3d5759479cdb2d37cce6b9376ea504db2ff90252a2e5b7cc89cc9ff2d8",
+                "sha256:aa4d33c06640f5352aca96e4b81afd8ab3b47337cc12089822d6f322ac772c81"
+            ],
+            "version": "==0.6.0"
+        },
+        "jsonasobj": {
+            "hashes": [
+                "sha256:b9e329dc1ceaae7cf5d5b214684a0b100e0dad0be6d5bbabac281ec35ddeca65",
+                "sha256:d52e0544a54a08f6ea3f77fa3387271e3648655e0eace2f21e825c26370e44a2"
+            ],
+            "version": "==1.3.1"
+        },
+        "jsonschema": {
+            "hashes": [
+                "sha256:4e5b3cf8216f577bee9ce139cbe72eca3ea4f292ec60928ff24758ce626cd163",
+                "sha256:c8a85b28d377cc7737e46e2d9f2b4f44ee3c0e1deac6bf46ddefc7187d30797a"
+            ],
+            "index": "pypi",
+            "version": "==3.2.0"
+        },
+        "linkml": {
+            "hashes": [
+                "sha256:94465b8b6fb13483ae66a5be6ffd45a8f3934ba83380c94f000feeea12ffd59b",
+                "sha256:e3fc92da077cb788d05f06afcd1769cad44a71b0869078c5c8e603e117b1009d"
+            ],
+            "index": "pypi",
+            "version": "==0.0.7"
+        },
+        "linkml-model": {
+            "hashes": [
+                "sha256:97723845aa1ed003342799802703bfeb00326bea225a95eecc5089d281693115",
+                "sha256:a0c27247e59566c3b66803b4c5d4ef83f8e27acf39bd2aac01f3482bf712e532"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==0.0.10"
+        },
+        "lxml": {
+            "hashes": [
+                "sha256:079f3ae844f38982d156efce585bc540c16a926d4436712cf4baee0cce487a3d",
+                "sha256:0fbcf5565ac01dff87cbfc0ff323515c823081c5777a9fc7703ff58388c258c3",
+                "sha256:122fba10466c7bd4178b07dba427aa516286b846b2cbd6f6169141917283aae2",
+                "sha256:1b7584d421d254ab86d4f0b13ec662a9014397678a7c4265a02a6d7c2b18a75f",
+                "sha256:26e761ab5b07adf5f555ee82fb4bfc35bf93750499c6c7614bd64d12aaa67927",
+                "sha256:289e9ca1a9287f08daaf796d96e06cb2bc2958891d7911ac7cae1c5f9e1e0ee3",
+                "sha256:2a9d50e69aac3ebee695424f7dbd7b8c6d6eb7de2a2eb6b0f6c7db6aa41e02b7",
+                "sha256:33bb934a044cf32157c12bfcfbb6649807da20aa92c062ef51903415c704704f",
+                "sha256:3439c71103ef0e904ea0a1901611863e51f50b5cd5e8654a151740fde5e1cade",
+                "sha256:39b78571b3b30645ac77b95f7c69d1bffc4cf8c3b157c435a34da72e78c82468",
+                "sha256:4289728b5e2000a4ad4ab8da6e1db2e093c63c08bdc0414799ee776a3f78da4b",
+                "sha256:4bff24dfeea62f2e56f5bab929b4428ae6caba2d1eea0c2d6eb618e30a71e6d4",
+                "sha256:542d454665a3e277f76954418124d67516c5f88e51a900365ed54a9806122b83",
+                "sha256:5a0a14e264069c03e46f926be0d8919f4105c1623d620e7ec0e612a2e9bf1c04",
+                "sha256:66e575c62792c3f9ca47cb8b6fab9e35bab91360c783d1606f758761810c9791",
+                "sha256:74f7d8d439b18fa4c385f3f5dfd11144bb87c1da034a466c5b5577d23a1d9b51",
+                "sha256:7610b8c31688f0b1be0ef882889817939490a36d0ee880ea562a4e1399c447a1",
+                "sha256:76fa7b1362d19f8fbd3e75fe2fb7c79359b0af8747e6f7141c338f0bee2f871a",
+                "sha256:7728e05c35412ba36d3e9795ae8995e3c86958179c9770e65558ec3fdfd3724f",
+                "sha256:8157dadbb09a34a6bd95a50690595e1fa0af1a99445e2744110e3dca7831c4ee",
+                "sha256:820628b7b3135403540202e60551e741f9b6d3304371712521be939470b454ec",
+                "sha256:884ab9b29feaca361f7f88d811b1eea9bfca36cf3da27768d28ad45c3ee6f969",
+                "sha256:89b8b22a5ff72d89d48d0e62abb14340d9e99fd637d046c27b8b257a01ffbe28",
+                "sha256:92e821e43ad382332eade6812e298dc9701c75fe289f2a2d39c7960b43d1e92a",
+                "sha256:b007cbb845b28db4fb8b6a5cdcbf65bacb16a8bd328b53cbc0698688a68e1caa",
+                "sha256:bc4313cbeb0e7a416a488d72f9680fffffc645f8a838bd2193809881c67dd106",
+                "sha256:bccbfc27563652de7dc9bdc595cb25e90b59c5f8e23e806ed0fd623755b6565d",
+                "sha256:c4f05c5a7c49d2fb70223d0d5bcfbe474cf928310ac9fa6a7c6dddc831d0b1d4",
+                "sha256:ce256aaa50f6cc9a649c51be3cd4ff142d67295bfc4f490c9134d0f9f6d58ef0",
+                "sha256:d2e35d7bf1c1ac8c538f88d26b396e73dd81440d59c1ef8522e1ea77b345ede4",
+                "sha256:df7c53783a46febb0e70f6b05df2ba104610f2fb0d27023409734a3ecbb78fb2",
+                "sha256:efac139c3f0bf4f0939f9375af4b02c5ad83a622de52d6dfa8e438e8e01d0eb0",
+                "sha256:efd7a09678fd8b53117f6bae4fa3825e0a22b03ef0a932e070c0bdbb3a35e654",
+                "sha256:f2380a6376dfa090227b663f9678150ef27543483055cc327555fb592c5967e2",
+                "sha256:f8380c03e45cf09f8557bdaa41e1fa7c81f3ae22828e1db470ab2a6c96d8bc23",
+                "sha256:f90ba11136bfdd25cae3951af8da2e95121c9b9b93727b1b896e3fa105b2f586"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
+            "version": "==4.6.3"
+        },
+        "parse": {
+            "hashes": [
+                "sha256:9ff82852bcb65d139813e2a5197627a94966245c897796760a3a2a8eb66f020b"
+            ],
+            "version": "==1.19.0"
+        },
+        "prefixcommons": {
+            "hashes": [
+                "sha256:2ff99e9f2c27f41e6beb831742ca88ddae129b2de6dcc81b0b27f0de69cb2e8a",
+                "sha256:a4a6decd6c1a2497b2b10193fa4ed69ed91cea20deb3a9781815b6bf3f3e1003",
+                "sha256:f820dc69f0eba1f6fd80bdb2e78420e4970f20dfb4c307fed77c607198ca69f2"
+            ],
+            "version": "==0.1.9"
+        },
+        "prologterms": {
+            "hashes": [
+                "sha256:9b8f6272dcae5a0a9257daa41cd455d5b060147486cea36623f91a3226a656e9",
+                "sha256:c63cfc291ccfa3e2eeea89eed93bc7fc0214a1f2d748a200de0a5fdd90e0426a"
+            ],
+            "version": "==0.0.6"
+        },
+        "pyjsg": {
+            "hashes": [
+                "sha256:08d9a80f6996af8862e8a2a4e2d90049af695c4ccd84187e7d7a48f600d37952",
+                "sha256:3c98d3153a2e4ca8ae8942a4bb213477c68519b145ca2d973648bcb9495208e7"
+            ],
+            "version": "==0.11.6"
+        },
+        "pyld": {
+            "hashes": [
+                "sha256:287445f888c3a332ccbd20a14844c66c2fcbaeab3c99acd506a0788e2ebb2f82"
+            ],
+            "version": "==2.0.3"
+        },
+        "pyparsing": {
+            "hashes": [
+                "sha256:c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1",
+                "sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b"
+            ],
+            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==2.4.7"
+        },
+        "pyrsistent": {
+            "hashes": [
+                "sha256:2e636185d9eb976a18a8a8e96efce62f2905fea90041958d8cc2a189756ebf3e"
+            ],
+            "markers": "python_version >= '3.5'",
+            "version": "==0.17.3"
+        },
+        "pyshex": {
+            "hashes": [
+                "sha256:3ea61c2a3f7436bac725bd5001072ba08d2dff5b836d5388ce9ff6f5251c2707",
+                "sha256:6c9cecd7726461c2105330a9b2d5fd054f0e7966bfc9e3a73e7136b8be63d089"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==0.7.20"
+        },
+        "pyshexc": {
+            "hashes": [
+                "sha256:6f75e26dfda605c994031a72ca74b2b0079e1f7b12ab713e030078d8fa05dc3a",
+                "sha256:ad83bb2a645f64becbf946d4bd170e35fd9b903616c7ee25d5a4ed188cf2d1dd"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==0.8.3"
+        },
+        "python-dateutil": {
+            "hashes": [
+                "sha256:73ebfe9dbf22e832286dafa60473e4cd239f8592f699aa5adaf10050e6e1823c",
+                "sha256:75bb3f31ea686f1197762692a9ee6a7550b59fc6ca3a1f4b5d7e32fb98e2da2a"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==2.8.1"
+        },
+        "pyyaml": {
+            "hashes": [
+                "sha256:08682f6b72c722394747bddaf0aa62277e02557c0fd1c42cb853016a38f8dedf",
+                "sha256:0f5f5786c0e09baddcd8b4b45f20a7b5d61a7e7e99846e3c799b05c7c53fa696",
+                "sha256:129def1b7c1bf22faffd67b8f3724645203b79d8f4cc81f674654d9902cb4393",
+                "sha256:294db365efa064d00b8d1ef65d8ea2c3426ac366c0c4368d930bf1c5fb497f77",
+                "sha256:3b2b1824fe7112845700f815ff6a489360226a5609b96ec2190a45e62a9fc922",
+                "sha256:3bd0e463264cf257d1ffd2e40223b197271046d09dadf73a0fe82b9c1fc385a5",
+                "sha256:4465124ef1b18d9ace298060f4eccc64b0850899ac4ac53294547536533800c8",
+                "sha256:49d4cdd9065b9b6e206d0595fee27a96b5dd22618e7520c33204a4a3239d5b10",
+                "sha256:4e0583d24c881e14342eaf4ec5fbc97f934b999a6828693a99157fde912540cc",
+                "sha256:5accb17103e43963b80e6f837831f38d314a0495500067cb25afab2e8d7a4018",
+                "sha256:607774cbba28732bfa802b54baa7484215f530991055bb562efbed5b2f20a45e",
+                "sha256:6c78645d400265a062508ae399b60b8c167bf003db364ecb26dcab2bda048253",
+                "sha256:72a01f726a9c7851ca9bfad6fd09ca4e090a023c00945ea05ba1638c09dc3347",
+                "sha256:74c1485f7707cf707a7aef42ef6322b8f97921bd89be2ab6317fd782c2d53183",
+                "sha256:895f61ef02e8fed38159bb70f7e100e00f471eae2bc838cd0f4ebb21e28f8541",
+                "sha256:8c1be557ee92a20f184922c7b6424e8ab6691788e6d86137c5d93c1a6ec1b8fb",
+                "sha256:bb4191dfc9306777bc594117aee052446b3fa88737cd13b7188d0e7aa8162185",
+                "sha256:bfb51918d4ff3d77c1c856a9699f8492c612cde32fd3bcd344af9be34999bfdc",
+                "sha256:c20cfa2d49991c8b4147af39859b167664f2ad4561704ee74c1de03318e898db",
+                "sha256:cb333c16912324fd5f769fff6bc5de372e9e7a202247b48870bc251ed40239aa",
+                "sha256:d2d9808ea7b4af864f35ea216be506ecec180628aced0704e34aca0b040ffe46",
+                "sha256:d483ad4e639292c90170eb6f7783ad19490e7a8defb3e46f97dfe4bacae89122",
+                "sha256:dd5de0646207f053eb0d6c74ae45ba98c3395a571a2891858e87df7c9b9bd51b",
+                "sha256:e1d4970ea66be07ae37a3c2e48b5ec63f7ba6804bdddfdbd3cfd954d25a82e63",
+                "sha256:e4fac90784481d221a8e4b1162afa7c47ed953be40d31ab4629ae917510051df",
+                "sha256:fa5ae20527d8e831e8230cbffd9f8fe952815b2b7dae6ffec25318803a7528fc",
+                "sha256:fd7f6999a8070df521b6384004ef42833b9bd62cfee11a09bda1079b4b704247",
+                "sha256:fdc842473cd33f45ff6bce46aea678a54e3d21f1b61a7750ce3c498eedfe25d6",
+                "sha256:fe69978f3f768926cfa37b867e3843918e012cf83f680806599ddce33c2c68b0"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'",
+            "version": "==5.4.1"
+        },
+        "rdflib": {
+            "hashes": [
+                "sha256:78149dd49d385efec3b3adfbd61c87afaf1281c30d3fcaf1b323b34f603fb155",
+                "sha256:88208ea971a87886d60ae2b1a4b2cdc263527af0454c422118d43fe64b357877"
+            ],
+            "version": "==5.0.0"
+        },
+        "rdflib-jsonld": {
+            "hashes": [
+                "sha256:4f7d55326405071c7bce9acf5484643bcb984eadb84a6503053367da207105ed"
+            ],
+            "version": "==0.5.0"
+        },
+        "rdflib-pyld-compat": {
+            "hashes": [
+                "sha256:d0270d64c71f19f00961108c1c175f593be47f056182af0897523c9e4e212525",
+                "sha256:f230d565d221efd9b28497034571c9c15e03a6fa9409b77277ca9295b94d072d"
+            ],
+            "version": "==0.1.0"
+        },
+        "requests": {
+            "hashes": [
+                "sha256:27973dd4a904a4f13b263a19c866c13b92a39ed1c964655f025f3f8d3d75b804",
+                "sha256:c210084e36a42ae6b9219e00e48287def368a26d03a048ddad7bfee44f75871e"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
+            "version": "==2.25.1"
+        },
+        "shexjsg": {
+            "hashes": [
+                "sha256:788991c4df2ca9b24258fb68c94107c3e140c70bbe398fb15f00338d2a9155e5",
+                "sha256:89fb39a4448f50fd4988108a0a2c7096aa51dd15cd89fef0bc3ad96e04929929"
+            ],
+            "version": "==0.7.1"
+        },
+        "six": {
+            "hashes": [
+                "sha256:30639c035cdb23534cd4aa2dd52c3bf48f06e5f4a941509c8bafd8ce11080259",
+                "sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==1.15.0"
+        },
+        "sparqlslurper": {
+            "hashes": [
+                "sha256:0808cf53923c9ffbf069f80310c73a41d3ae170c266d805b56b6978a066f63e3",
+                "sha256:e1decb006837c5b8f1f404710d86a36a6cd09301910c79165094a1354ddae487"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==0.4.1"
+        },
+        "sparqlwrapper": {
+            "hashes": [
+                "sha256:17ec44b08b8ae2888c801066249f74fe328eec25d90203ce7eadaf82e64484c7",
+                "sha256:357ee8a27bc910ea13d77836dbddd0b914991495b8cc1bf70676578155e962a8",
+                "sha256:8cf6c21126ed76edc85c5c232fd6f77b9f61f8ad1db90a7147cdde2104aff145",
+                "sha256:c7f9c9d8ebb13428771bc3b6dee54197422507dcc3dea34e30d5dcfc53478dec",
+                "sha256:d6a66b5b8cda141660e07aeb00472db077a98d22cb588c973209c7336850fb3c"
+            ],
+            "version": "==1.8.5"
+        },
+        "testfixtures": {
+            "hashes": [
+                "sha256:5ec3a0dd6f71cc4c304fbc024a10cc293d3e0b852c868014b9f233203e149bda",
+                "sha256:9ed31e83f59619e2fa17df053b241e16e0608f4580f7b5a9333a0c9bdcc99137"
+            ],
+            "version": "==6.17.1"
+        },
+        "urllib3": {
+            "hashes": [
+                "sha256:2f4da4594db7e1e110a944bb1b551fdf4e6c136ad42e4234131391e21eb5b0df",
+                "sha256:e7b021f7241115872f92f43c6508082facffbd1c048e3c6e2bb9c2a157e28937"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'",
+            "version": "==1.26.4"
+        },
+        "watchdog": {
+            "hashes": [
+                "sha256:0ba2c2526dc81a241e3b0f018a447a5ca634fa1f01fc5fa2a07c87ee04d730a7",
+                "sha256:1583ee70d78226d897cbc85cfd5b88108340450e0214a704a4919443434d3c32",
+                "sha256:3bf9132a6c609ca9fa96df3e8309acaee930b1faf46212d7c296f2bce03f5264",
+                "sha256:4288d3a984324db492e57aa169666238a2578f0af5a081685526608fb9f6bd61",
+                "sha256:4607156004c36c1cbd8b693b9516a3463646159299404e007cc292f51934c930",
+                "sha256:51ad0342ecb4733796e94980f2430b2333e12ead973d3e18f5514cd77a24fa85",
+                "sha256:6b760cf207bf4d533155853904047e75eb3a2d629bfd320c3f4f8d07abbc38d5",
+                "sha256:7fea9428ab2cd577d7dc571036b2450361802c43d7a546e72eead95c21239c9a",
+                "sha256:819d7e77594aa3108f9ad9e896b003914ec778fdf9827d9f940ca5e6db5416ce",
+                "sha256:8e82707878e3defc46e8a4d861cde0c89561fba8a91b3609742213fa9d07fc16",
+                "sha256:9fe3ea15f9020aa7f129f700341850ee768730c67e89d8256c224c4f26c86670",
+                "sha256:a06e595e05cc31a882031367e0f6c2b19160b1d7e881857c16121e3cda32494d",
+                "sha256:a679d03f52a9e3ea3efb77b459e9eba05c7c687f48e4d17ce20bc0e36f867d9a",
+                "sha256:b565838318e134e41d78f056194dff6bbd7b85fef67f9ee6f01168146bf04048",
+                "sha256:b8727f84a3c7dd21138d92186181d015af45168e0af895ffdc553a28019494ef",
+                "sha256:be4c578fa148a9cbc64451a3af26c4ee55d59c33f5438bcffc1956092df0888b",
+                "sha256:c678b51fb89c76816004c8234ac827977c23912c3826e263adbfb5dbe161e8dc"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==2.0.3"
+        }
+    },
+    "develop": {}
+}

--- a/crdc-h-model/crdc-h-model-json-schema.json
+++ b/crdc-h-model/crdc-h-model-json-schema.json
@@ -1,0 +1,272 @@
+{
+   "$id": "https://example.org/ccdh/model/MVPv0",
+   "$schema": "http://json-schema.org/draft-07/schema#",
+   "definitions": {
+      "CodeableConcept": {
+         "additionalProperties": false,
+         "description": "",
+         "properties": {
+            "coding": {
+               "description": "A reference to a code defined by a terminology system",
+               "items": {
+                  "$ref": "#/definitions/Coding"
+               },
+               "type": "array"
+            },
+            "text": {
+               "description": "A human language representation of the concept represented by the Coding",
+               "type": "string"
+            }
+         },
+         "required": [],
+         "title": "CodeableConcept",
+         "type": "object"
+      },
+      "Coding": {
+         "additionalProperties": false,
+         "description": "",
+         "properties": {
+            "code": {
+               "description": "The value of the code itself.",
+               "type": "string"
+            },
+            "display": {
+               "description": "A human-readable name for the code.",
+               "type": "string"
+            },
+            "system": {
+               "description": "The code system where the code is defined.",
+               "type": "string"
+            },
+            "version": {
+               "description": "The version of the code system.",
+               "type": "string"
+            }
+         },
+         "required": [],
+         "title": "Coding",
+         "type": "object"
+      },
+      "Identifier": {
+         "additionalProperties": false,
+         "description": "",
+         "properties": {
+            "system": {
+               "description": "The system or namespace that defines the identifier.",
+               "type": "string"
+            },
+            "type": {
+               "$ref": "#/definitions/CodeableConcept",
+               "description": "A code that defines the type of the identifier."
+            },
+            "value": {
+               "description": "The value of the identifier, as defined by the system.",
+               "type": "string"
+            }
+         },
+         "required": [],
+         "title": "Identifier",
+         "type": "object"
+      },
+      "Patient": {
+         "additionalProperties": false,
+         "description": "",
+         "properties": {
+            "id": {
+               "description": "The 'logical' identifier of the entity in the system of record, e.g. a UUID.  This 'id' is unique within a given system. The identified entity may have a different 'id' in a different system.",
+               "type": "string"
+            },
+            "identifier": {
+               "description": "A 'business' identifier for the entity, typically as provided by an external system or authority, that persists across implementing systems. ",
+               "items": {
+                  "$ref": "#/definitions/Identifier"
+               },
+               "type": "array"
+            },
+            "taxon": {
+               "$ref": "#/definitions/CodeableConcept",
+               "description": "The taxonomic group (e.g. species) of the patient."
+            }
+         },
+         "required": [
+            "id"
+         ],
+         "title": "Patient",
+         "type": "object"
+      },
+      "Project": {
+         "additionalProperties": false,
+         "description": "",
+         "properties": {
+            "id": {
+               "type": "string"
+            }
+         },
+         "required": [
+            "id"
+         ],
+         "title": "Project",
+         "type": "object"
+      },
+      "Quantity": {
+         "additionalProperties": false,
+         "description": "",
+         "properties": {
+            "comparator": {
+               "$ref": "#/definitions/Coding",
+               "description": "How to understand the value  . . .   < | <= | >= | >"
+            },
+            "unit": {
+               "$ref": "#/definitions/Coding",
+               "description": "Unit representation (e.g. mg, mL)"
+            },
+            "value": {
+               "description": "Numerical value (with implicit precision)",
+               "type": "string"
+            }
+         },
+         "required": [],
+         "title": "Quantity",
+         "type": "object"
+      },
+      "ResearchSubject": {
+         "additionalProperties": false,
+         "description": "",
+         "properties": {
+            "associated_patient": {
+               "description": "A reference to the Patient that is this ResearchSubject",
+               "type": "string"
+            },
+            "associated_project": {
+               "description": "A reference to the Project(s) of which this ResearchSubject is a member",
+               "items": {
+                  "type": "string"
+               },
+               "type": "array"
+            },
+            "id": {
+               "description": "The 'logical' identifier of the entity in the system of record, e.g. a UUID.  This 'id' is unique within a given system. The identified entity may have a different 'id' in a different system.",
+               "type": "string"
+            },
+            "identifier": {
+               "description": "A 'business' identifier for the entity, typically as provided by an external system or authority, that persists across implementing systems  (i.e. a  'logical' identifier). Uses a specialized, complex 'Identifier' data type to capture information about the source of the business identifier. ",
+               "items": {
+                  "$ref": "#/definitions/Identifier"
+               },
+               "type": "array"
+            },
+            "primary_disease_site": {
+               "$ref": "#/definitions/CodeableConcept",
+               "description": "The text term used to describe the primary site of disease, as categorized by the World Health Organization's (WHO) International Classification of Diseases for Oncology (ICD-O). This categorization groups cases into general categories."
+            },
+            "primary_disease_type": {
+               "$ref": "#/definitions/CodeableConcept",
+               "description": "The text term used to describe the type of malignant disease, as categorized by the World Health Organization's (WHO) International Classification of Diseases for Oncology (ICD-O). "
+            }
+         },
+         "required": [
+            "id"
+         ],
+         "title": "ResearchSubject",
+         "type": "object"
+      },
+      "Specimen": {
+         "additionalProperties": false,
+         "description": "",
+         "properties": {
+            "analyte_concentration": {
+               "$ref": "#/definitions/Quantity",
+               "description": "The concentration of an extracted analyte that is present in a specimen (specifically, in a specimen of type 'analyte', or an 'aliquot' derived from an analyte). e.g. the concentration of DNA in a specimen created through extracting DNA from a blood sample."
+            },
+            "analyte_concentration_method": {
+               "$ref": "#/definitions/CodeableConcept",
+               "description": "The method used to determine the concentration of purified analyte  within a solution."
+            },
+            "analyte_type": {
+               "$ref": "#/definitions/CodeableConcept",
+               "description": "When the specimen is of type 'analyte' or 'aliquot', this is the type of substance the analyte represents (e.g. DNA, RNA)"
+            },
+            "associated_project": {
+               "description": "The Project associated with the specimen.",
+               "type": "string"
+            },
+            "cellular_composition": {
+               "$ref": "#/definitions/CodeableConcept",
+               "description": "The cellular composition of the sample"
+            },
+            "current_volume": {
+               "description": "The current total volume of the specimen, at the time of recording.",
+               "items": {
+                  "$ref": "#/definitions/Quantity"
+               },
+               "type": "array"
+            },
+            "current_weight": {
+               "description": "The current weight of the specimen, at the time of recording (as opposed to an initial weight before its processing or portioning).",
+               "items": {
+                  "$ref": "#/definitions/Quantity"
+               },
+               "type": "array"
+            },
+            "derived_from_specimen": {
+               "description": "A source/parent specimen from which this one was directly derived.",
+               "items": {
+                  "type": "string"
+               },
+               "type": "array"
+            },
+            "derived_from_subject": {
+               "description": "The Patient/ResearchSubject, or Biologically Derived Materal (e.g. a cell line, tissue culture, organoid) from which the specimen was directly or indirectly derived.",
+               "type": "string"
+            },
+            "general_tissue_morphology": {
+               "$ref": "#/definitions/CodeableConcept",
+               "description": "A term describing at a high-level the kind of tissue collected in a specimen, with respect to disease status or proximity to tumor tissue (e.g. is it normal, abnormal, tumor, tumor-adjacent). \n"
+            },
+            "id": {
+               "description": "The 'logical' identifier of the entity in the system of record, e.g. a UUID.  This 'id' is unique within a given system. The identified entity may have a different 'id' in a different system.",
+               "type": "string"
+            },
+            "identifier": {
+               "description": "A 'business' identifier  or accession number for the entity, typically as provided by an external system or authority, that persists across implementing systems.",
+               "items": {
+                  "$ref": "#/definitions/Identifier"
+               },
+               "type": "array"
+            },
+            "matched_normal_flag": {
+               "description": "A flag indicating that there is no matched normal aliquot for this case that can be used for variant calling purposes.",
+               "items": {
+                  "$ref": "#/definitions/CodeableConcept"
+               },
+               "type": "array"
+            },
+            "qualification_status_flag": {
+               "$ref": "#/definitions/CodeableConcept",
+               "description": "A flag indicating whether the specimen is qualified or disqualified for data analysis in a study."
+            },
+            "source_material_type": {
+               "$ref": "#/definitions/CodeableConcept",
+               "description": "The general kind of material from which the specimen was derived, indicating the physical nature of the source material. "
+            },
+            "specific_tissue_morphology": {
+               "$ref": "#/definitions/CodeableConcept",
+               "description": "A term describing the specific pathology exhibited by the tissue in a specimen."
+            },
+            "specimen_type": {
+               "$ref": "#/definitions/CodeableConcept",
+               "description": "The high-level type of the specimen, based on its how it has been derived from the original extracted sample. \n"
+            }
+         },
+         "required": [
+            "id"
+         ],
+         "title": "Specimen",
+         "type": "object"
+      }
+   },
+   "properties": {},
+   "title": "CCDH-MVP",
+   "type": "object"
+}
+

--- a/crdc-h-model/datatypes.yaml
+++ b/crdc-h-model/datatypes.yaml
@@ -1,0 +1,96 @@
+name: datatypes
+id: https://example.org/ccdh/model/datatypes
+title: Data Types used by the CCDH model
+imports:
+- biolinkml:types
+license: https://creativecommons.org/publicdomain/zero/1.0/
+prefixes:
+  biolinkml: https://w3id.org/biolink/biolinkml/
+  types: https://example.org/ccdh/datatypes/
+default_prefix: types
+types:
+  url:
+    name: url
+    typeof: string
+classes:
+  Identifier:
+    name: Identifier
+    attributes:
+      value:
+        name: value
+        description: The value of the identifier, as defined by the system.
+        range: string
+      system:
+        name: system
+        description: The system or namespace that defines the identifier.
+        range: string
+        multivalued: false
+        required: false
+      type:
+        name: type
+        description: A code that defines the type of the identifier.
+        range: CodeableConcept
+        multivalued: false
+        required: false
+  Coding:
+    name: Coding
+    attributes:
+      code:
+        name: code
+        description: The value of the code itself.
+        range: string
+        multivalued: false
+        required: false
+      display:
+        name: display
+        description: A human-readable name for the code.
+        range: string
+        multivalued: false
+        required: false
+      system:
+        name: system
+        description: The code system where the code is defined.
+        range: string
+        multivalued: false
+        required: false
+      version:
+        name: version
+        description: The version of the code system.
+        range: string
+        multivalued: false
+        required: false
+  Quantity:
+    name: Quantity
+    attributes:
+      value:
+        name: value
+        description: Numerical value (with implicit precision)
+        range: decimal
+      unit:
+        name: unit
+        description: Unit representation (e.g. mg, mL)
+        range: Coding
+        multivalued: false
+        required: false
+      comparator:
+        name: comparator
+        description: How to understand the value  . . .   < | <= | >= | >
+        range: Coding
+        multivalued: false
+        required: false
+  CodeableConcept:
+    name: CodeableConcept
+    attributes:
+      coding:
+        name: coding
+        description: A reference to a code defined by a terminology system
+        range: Coding
+        multivalued: true
+        required: false
+      text:
+        name: text
+        description: A human language representation of the concept represented by
+          the Coding
+        range: string
+        multivalued: false
+        required: false

--- a/crdc-h-model/entities.yaml
+++ b/crdc-h-model/entities.yaml
@@ -1,0 +1,286 @@
+name: CCDH-MVP
+notes:
+- derived from [CDM_Dictionary_v1](https://docs.google.com/spreadsheets/d/1oWS7cao-fgz2MKWtyr8h2dEL9unX__0bJrWKv6mQmM4/)
+id: https://example.org/ccdh/model/MVPv0
+title: MVPv0
+version: v0
+imports:
+- datatypes
+- prefixes
+license: https://creativecommons.org/publicdomain/zero/1.0/
+prefixes:
+  biolinkml: https://w3id.org/biolink/biolinkml/
+  ccdh: https://example.org/ccdh/
+default_prefix: ccdh
+slots:
+  id:
+    name: id
+    multivalued: false
+    required: true
+    key: true
+classes:
+  Entity:
+    name: Entity
+    description: Any resource that has its own identifier
+    abstract: true
+    slots:
+    - id
+  Specimen:
+    name: Specimen
+    is_a: Entity
+    slot_usage:
+      id:
+        name: id
+        description: The 'logical' identifier of the entity in the system of record,
+          e.g. a UUID.  This 'id' is unique within a given system. The identified
+          entity may have a different 'id' in a different system.
+        range: string
+        multivalued: false
+        required: true
+    attributes:
+      identifier:
+        name: identifier
+        description: A 'business' identifier  or accession number for the entity,
+          typically as provided by an external system or authority, that persists
+          across implementing systems.
+        range: Identifier
+        multivalued: true
+        required: false
+      associated_project:
+        name: associated_project
+        description: The Project associated with the specimen.
+        range: Project
+        multivalued: false
+        required: false
+      specimen_type:
+        name: specimen_type
+        description: "The high-level type of the specimen, based on its how it has\
+          \ been derived from the original extracted sample. \n"
+        comments:
+        - 'Example values: Initial Sample; Portion; Aliquot; Analyte, Pool'
+        values_from: https://example.org/ccdh/valuesets/CDM/Specimen/specimen_type
+        range: CodeableConcept
+        multivalued: false
+        required: false
+      analyte_type:
+        name: analyte_type
+        description: When the specimen is of type 'analyte' or 'aliquot', this is
+          the type of substance the analyte represents (e.g. DNA, RNA)
+        comments:
+        - 'Example values: DNA; FFPE DNA; GenomePlex (Rubicon) Amplified DNA; Repli-G
+          (Qiagen) DNA; '
+        - RNA; FFPE RNA
+        values_from: https://example.org/ccdh/valuesets/CDM/Specimen/analyte_type
+        range: CodeableConcept
+        multivalued: false
+        required: false
+      derived_from_specimen:
+        name: derived_from_specimen
+        description: A source/parent specimen from which this one was directly derived.
+        range: Specimen
+        multivalued: true
+        required: false
+      derived_from_subject:
+        name: derived_from_subject
+        description: The Patient/ResearchSubject, or Biologically Derived Materal
+          (e.g. a cell line, tissue culture, organoid) from which the specimen was
+          directly or indirectly derived.
+        range: Patient
+        multivalued: false
+        required: false
+      source_material_type:
+        name: source_material_type
+        description: 'The general kind of material from which the specimen was derived,
+          indicating the physical nature of the source material. '
+        comments:
+        - 'Example values: Tissue, Blood, Tumor Aspirate; Cell Line; Expanded Next
+          Generation Cancer Model; Pleural Effusion;  Xenograft Tissue'
+        values_from: https://example.org/ccdh/valuesets/CDM/Specimen/source_material_type
+        range: CodeableConcept
+        multivalued: false
+        required: false
+      cellular_composition:
+        name: cellular_composition
+        description: The cellular composition of the sample
+        comments:
+        - 'Example values: 2D Classical Conditionally Reprogrammed Cells; Adherent
+          Cell Line; Bone Marrow Components;'
+        - Buccal Cells; Buffy Coat; Derived Cell Line; Granulocytes; Pleural Effusion;
+          Human Original Cells;
+        - 'Liquid Suspension Cell Line '
+        values_from: https://example.org/ccdh/valuesets/CDM/Specimen/cellular_composition
+        range: CodeableConcept
+        multivalued: false
+        required: false
+      general_tissue_morphology:
+        name: general_tissue_morphology
+        description: "A term describing at a high-level the kind of tissue collected\
+          \ in a specimen, with respect to disease status or proximity to tumor tissue\
+          \ (e.g. is it normal, abnormal, tumor, tumor-adjacent). \n"
+        comments:
+        - 'Example values: Tumor;  Normal;  Abnormal;  Peritumoral; not applicable'
+        values_from: https://example.org/ccdh/valuesets/CDM/Specimen/general_tissue_morphology
+        range: CodeableConcept
+        multivalued: false
+        required: false
+      specific_tissue_morphology:
+        name: specific_tissue_morphology
+        description: A term describing the specific pathology exhibited by the tissue
+          in a specimen.
+        comments:
+        - 'Example values: Non cancerous tissue; Lung Cancer (all types); CNS, medulloblastoma;
+          00;  01;  02; Melanocytic hyperplasia; Atypical melanocytic proliferation;
+          Melanoma in situ, superficial spreading'
+        values_from: https://example.org/ccdh/valuesets/CDM/Specimen/specific_tissue_morphology
+        range: CodeableConcept
+        multivalued: false
+        required: false
+      current_weight:
+        name: current_weight
+        description: The current weight of the specimen, at the time of recording
+          (as opposed to an initial weight before its processing or portioning).
+        range: Quantity
+        multivalued: true
+        required: false
+      current_volume:
+        name: current_volume
+        description: The current total volume of the specimen, at the time of recording.
+        range: Quantity
+        multivalued: true
+        required: false
+      analyte_concentration:
+        name: analyte_concentration
+        description: The concentration of an extracted analyte that is present in
+          a specimen (specifically, in a specimen of type 'analyte', or an 'aliquot'
+          derived from an analyte). e.g. the concentration of DNA in a specimen created
+          through extracting DNA from a blood sample.
+        range: Quantity
+        multivalued: false
+        required: false
+      analyte_concentration_method:
+        name: analyte_concentration_method
+        description: The method used to determine the concentration of purified analyte  within
+          a solution.
+        comments:
+        - 'Example values: DDA; DIA; SRM'
+        values_from: https://example.org/ccdh/valuesets/CDM/Specimen/analyte_concentration_method
+        range: CodeableConcept
+        multivalued: false
+        required: false
+      matched_normal_flag:
+        name: matched_normal_flag
+        description: A flag indicating that there is no matched normal aliquot for
+          this case that can be used for variant calling purposes.
+        comments:
+        - 'Example values: no matched normal wgs; no matched normal wxs, no matched
+          normal  targeted'
+        values_from: https://example.org/ccdh/valuesets/CDM/Specimen/matched_normal_flag
+        range: CodeableConcept
+        multivalued: true
+        required: false
+      qualification_status_flag:
+        name: qualification_status_flag
+        description: A flag indicating whether the specimen is qualified or disqualified
+          for data analysis in a study.
+        comments:
+        - 'Example values: Qualified; Disqualified'
+        values_from: https://example.org/ccdh/valuesets/CDM/Specimen/qualification_status_flag
+        range: CodeableConcept
+        multivalued: false
+        required: false
+  Patient:
+    name: Patient
+    is_a: Entity
+    slot_usage:
+      id:
+        name: id
+        description: The 'logical' identifier of the entity in the system of record,
+          e.g. a UUID.  This 'id' is unique within a given system. The identified
+          entity may have a different 'id' in a different system.
+        range: string
+        required: true
+    attributes:
+      identifier:
+        name: identifier
+        description: 'A ''business'' identifier for the entity, typically as provided
+          by an external system or authority, that persists across implementing systems. '
+        range: Identifier
+        multivalued: true
+        required: false
+      taxon:
+        name: taxon
+        description: The taxonomic group (e.g. species) of the patient.
+        comments:
+        - 'Example values: Trichomonas vaginalis; Bemisia tabaci (Gennadius); Mus
+          musculus; '
+        values_from: https://example.org/ccdh/valuesets/CDM/Patient/taxon
+        range: CodeableConcept
+        multivalued: false
+        required: false
+  ResearchSubject:
+    name: ResearchSubject
+    is_a: Entity
+    slot_usage:
+      id:
+        name: id
+        description: The 'logical' identifier of the entity in the system of record,
+          e.g. a UUID.  This 'id' is unique within a given system. The identified
+          entity may have a different 'id' in a different system.
+        range: string
+        required: true
+    attributes:
+      identifier:
+        name: identifier
+        description: 'A ''business'' identifier for the entity, typically as provided
+          by an external system or authority, that persists across implementing systems  (i.e.
+          a  ''logical'' identifier). Uses a specialized, complex ''Identifier'' data
+          type to capture information about the source of the business identifier. '
+        range: Identifier
+        multivalued: true
+        required: false
+      associated_project:
+        name: associated_project
+        description: A reference to the Project(s) of which this ResearchSubject is
+          a member
+        range: Project
+        multivalued: true
+        required: false
+      primary_disease_type:
+        name: primary_disease_type
+        description: 'The text term used to describe the type of malignant disease,
+          as categorized by the World Health Organization''s (WHO) International Classification
+          of Diseases for Oncology (ICD-O). '
+        comments:
+        - 'Example values: Acinar Cell Neoplasms; Adenomas and Adenocarcinomas; Adnexal
+          and Skin Appendage Neoplasms; '
+        values_from: https://example.org/ccdh/valuesets/CDM/ResearchSubject/primary_disease_type
+        range: CodeableConcept
+        multivalued: false
+        required: false
+      primary_disease_site:
+        name: primary_disease_site
+        description: The text term used to describe the primary site of disease, as
+          categorized by the World Health Organization's (WHO) International Classification
+          of Diseases for Oncology (ICD-O). This categorization groups cases into
+          general categories.
+        comments:
+        - 'Example values: Accessory sinuses; Adrenal gland; Anus and anal canal; '
+        values_from: https://example.org/ccdh/valuesets/CDM/ResearchSubject/primary_disease_site
+        range: CodeableConcept
+        multivalued: false
+        required: false
+      associated_patient:
+        name: associated_patient
+        description: A reference to the Patient that is this ResearchSubject
+        range: Patient
+        multivalued: false
+        required: false
+  Project:
+    name: Project
+    is_a: Entity
+    slot_usage:
+      id:
+        name: id
+        description: ''
+        range: string
+        required: true

--- a/crdc-h-model/prefixes.yaml
+++ b/crdc-h-model/prefixes.yaml
@@ -1,0 +1,22 @@
+id: https://ccdh.org/model/prefixes
+name: prefixes
+title: URI Prefixes used by the CCDH Model
+license: https://creativecommons.org/publicdomain/zero/1.0/
+
+prefixes:
+  ccdh: https://example.org/ccdh/
+  specimen: https://ccdh.org/specimen/
+  xsd: http://www.w3.org/2001/XMLSchema#
+  biolinkml: https://w3id.org/biolink/biolinkml/
+  ADM: https://ccdh.org/models/ADM/
+  FHIR: http://hl7.org/fhir/
+  BRIDG: https://fill.me.in/BRIDG/
+  GDC: http://fill.me.in/GDC
+  PDC: http://fill.me.in/PDC
+  ICDC: http://fill.me.in/ICDC
+  HTAN: http://fill.me.in/ICDC
+
+default_prefix: biolinkml
+
+imports:
+  - biolinkml:types

--- a/crdc-h-model/prefixes.yaml
+++ b/crdc-h-model/prefixes.yaml
@@ -11,10 +11,10 @@ prefixes:
   ADM: https://ccdh.org/models/ADM/
   FHIR: http://hl7.org/fhir/
   BRIDG: https://fill.me.in/BRIDG/
-  GDC: http://fill.me.in/GDC
-  PDC: http://fill.me.in/PDC
-  ICDC: http://fill.me.in/ICDC
-  HTAN: http://fill.me.in/ICDC
+  GDC: http://fill.me.in/GDC/
+  PDC: http://fill.me.in/PDC/
+  ICDC: http://fill.me.in/ICDC/
+  HTAN: http://fill.me.in/HTAN/
 
 default_prefix: biolinkml
 


### PR DESCRIPTION
This PR adds support for LinkML data validation. I've copied in the latest version of the CRDC-H model in LinkML as generated by Dazhi's script; I then used that to generate a JSON Schema that I can use to validate the data up to a point.

This might end up being subsumed into #3 or separated out in some other way. Let us see.