### PR TITLE
Started updating GDC to CCDH conversion to use crdch_model

### DIFF
--- a/GDC to CCDH conversion.ipynb
+++ b/GDC to CCDH conversion.ipynb
@@ -38,10 +38,28 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 3,
    "id": "0b848016",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Collecting pandas\n",
+      "  Downloading pandas-1.3.3-cp39-cp39-macosx_10_9_x86_64.whl (11.6 MB)\n",
+      "\u001b[K     |████████████████████████████████| 11.6 MB 4.5 MB/s eta 0:00:01\n",
+      "\u001b[?25hRequirement already satisfied: python-dateutil>=2.7.3 in /Users/gaurav/.local/share/virtualenvs/example-data-Jkfe_NKr/lib/python3.9/site-packages (from pandas) (2.8.2)\n",
+      "Requirement already satisfied: pytz>=2017.3 in /Users/gaurav/.local/share/virtualenvs/example-data-Jkfe_NKr/lib/python3.9/site-packages (from pandas) (2021.3)\n",
+      "Collecting numpy>=1.17.3\n",
+      "  Downloading numpy-1.21.2-cp39-cp39-macosx_10_9_x86_64.whl (17.0 MB)\n",
+      "\u001b[K     |████████████████████████████████| 17.0 MB 7.7 MB/s eta 0:00:01\n",
+      "\u001b[?25hRequirement already satisfied: six>=1.5 in /Users/gaurav/.local/share/virtualenvs/example-data-Jkfe_NKr/lib/python3.9/site-packages (from python-dateutil>=2.7.3->pandas) (1.16.0)\n",
+      "Installing collected packages: numpy, pandas\n",
+      "Successfully installed numpy-1.21.2 pandas-1.3.3\n"
+     ]
+    }
+   ],
    "source": [
     "import sys\n",
     "\n",
@@ -72,7 +90,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 4,
    "id": "8e146c12",
    "metadata": {
     "scrolled": false
@@ -591,7 +609,7 @@
        "[560 rows x 25 columns]"
       ]
      },
-     "execution_count": 3,
+     "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -620,7 +638,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 13,
    "id": "a16e6db1",
    "metadata": {
     "scrolled": false
@@ -643,22 +661,22 @@
       " - Value \"aliquot\": A specimen that results from the division of some parent specimen into equal amounts for downstream analysis.\n",
       " - Value \"analyte\": A specimen generated through the extraction of a specified class of substance/chemical (e.g. DNA, RNA, protein) from a parent specimen, which is stored in solution as an analyte.\n",
       " - Value \"slide\": A specimen that is mounted on a slide or coverslip for microscopic analysis.\n",
-      " - Value \"initial sample\": A specimen representing the material that was directly collected from a subject (i.e. not generated through portioning, aliquoting, or analyte extraction from an existing specimen).\n"
+      " - Value \"Fresh Specimen\": A specimen representing the material that was directly collected from a subject (i.e. not generated through portioning, aliquoting, or analyte extraction from an existing specimen).\n"
      ]
     }
    ],
    "source": [
-    "from ccdh import ccdhmodel as ccdh\n",
+    "import crdch_model\n",
     "\n",
     "# Documentation for an entity.\n",
-    "print(f\"Documentation for Specimen: {ccdh.Specimen.__doc__}\")\n",
+    "print(f\"Documentation for Specimen: {crdch_model.Specimen.__doc__}\")\n",
     "\n",
     "# Documentation for an enumeration.\n",
-    "print(f\"Documentation for Specimen.specimen_type: {ccdh.EnumCCDHSpecimenSpecimenType.__doc__}\")\n",
+    "print(f\"Documentation for Specimen.specimen_type: {crdch_model.EnumCRDCHSpecimenSpecimenType.__doc__}\")\n",
     "\n",
     "# List of permissible values for Specimen.specimen_type\n",
     "print(\"Permissible values in enumeration Specimen.specimen_type:\")\n",
-    "pvalues = [pv for key, pv in ccdh.EnumCCDHSpecimenSpecimenType.__dict__.items() if isinstance(pv, ccdh.PermissibleValue)]\n",
+    "pvalues = [pv for key, pv in ccdh.EnumCRDCHSpecimenSpecimenType.__dict__.items() if isinstance(pv, ccdh.PermissibleValue)]\n",
     "for pv in pvalues:\n",
     "    print(f' - Value \"{pv.text}\": {pv.description}')"
    ]
@@ -680,26 +698,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 15,
    "id": "76578a61",
    "metadata": {},
    "outputs": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Could not create BodySite: Unknown EnumCCDHBodySiteSite enumeration code: Laryn\n"
+     "ename": "TypeError",
+     "evalue": "crdch_model.CodeableConcept() argument after ** must be a mapping, not str",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mTypeError\u001b[0m                                 Traceback (most recent call last)",
+      "\u001b[0;32m/var/folders/j7/wl1qrc1n7fv9vnszw_0dsm680000gn/T/ipykernel_9349/1305827346.py\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m     20\u001b[0m \u001b[0;31m# Try to create a body site for a site name not currently included in the CCDH model.\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     21\u001b[0m \u001b[0;32mtry\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 22\u001b[0;31m     \u001b[0mcreate_body_site\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m'Laryn'\u001b[0m\u001b[0;34m)\u001b[0m \u001b[0;31m# Note misspelling.\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     23\u001b[0m \u001b[0;32mexcept\u001b[0m \u001b[0mValueError\u001b[0m \u001b[0;32mas\u001b[0m \u001b[0mv\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     24\u001b[0m     \u001b[0mprint\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34mf'Could not create BodySite: {v}'\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m/var/folders/j7/wl1qrc1n7fv9vnszw_0dsm680000gn/T/ipykernel_9349/1305827346.py\u001b[0m in \u001b[0;36mcreate_body_site\u001b[0;34m(site_name)\u001b[0m\n\u001b[1;32m     16\u001b[0m         \u001b[0;32mreturn\u001b[0m \u001b[0mccdh\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mBodySite\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0msite\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0msite_mappings\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0msite_name\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     17\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 18\u001b[0;31m     \u001b[0;32mreturn\u001b[0m \u001b[0mccdh\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mBodySite\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0msite\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0msite_name\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     19\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     20\u001b[0m \u001b[0;31m# Try to create a body site for a site name not currently included in the CCDH model.\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/.local/share/virtualenvs/example-data-Jkfe_NKr/lib/python3.9/site-packages/crdch_model.py\u001b[0m in \u001b[0;36m__init__\u001b[0;34m(self, site, qualifier, **kwargs)\u001b[0m\n",
+      "\u001b[0;32m~/.local/share/virtualenvs/example-data-Jkfe_NKr/lib/python3.9/site-packages/crdch_model.py\u001b[0m in \u001b[0;36m__post_init__\u001b[0;34m(self, *_, **kwargs)\u001b[0m\n\u001b[1;32m    192\u001b[0m             \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mMissingRequiredField\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m\"site\"\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    193\u001b[0m         \u001b[0;32mif\u001b[0m \u001b[0;32mnot\u001b[0m \u001b[0misinstance\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0msite\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mCodeableConcept\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 194\u001b[0;31m             \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0msite\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mCodeableConcept\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m**\u001b[0m\u001b[0mas_dict\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0msite\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    195\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    196\u001b[0m         \u001b[0;32mif\u001b[0m \u001b[0;32mnot\u001b[0m \u001b[0misinstance\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mqualifier\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mlist\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;31mTypeError\u001b[0m: crdch_model.CodeableConcept() argument after ** must be a mapping, not str"
      ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "BodySite(site=(text='Larynx', description='Larynx'), qualifier=[])"
-      ]
-     },
-     "execution_count": 5,
-     "metadata": {},
-     "output_type": "execute_result"
     }
    ],
    "source": [
@@ -713,7 +728,7 @@
     "    # Some body sites are not currently included in the CCDH model. We will need to translate these sites\n",
     "    # into values that *are* included in the CCDH model.\n",
     "    site_mappings = {\n",
-    "        'Larynx, NOS': ccdh.EnumCCDHBodySiteSite.Larynx\n",
+    "        'Larynx, NOS': crdch_model.EnumCRDCHBodySiteSite.Larynx\n",
     "    }\n",
     "    \n",
     "    # Map values if needed. Otherwise, pass them through unmapped.\n",
@@ -2059,7 +2074,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.6"
+   "version": "3.9.7"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This PR starts the process of updating the GDC to CCDH conversion Jupyter Notebook to use crdch_model rather than the using the `ccdh/ccdhmodel.py` file included in this repo. Since there have been some major changes to the model since that release, this will require the code to be updated as well.

WIP: Apart from fully converting this Jupyter Notebook, this PR should try to create a GitHub Action (#18) to ensure that all included Jupyter Notebooks are executable without any errors.

Closes #25.